### PR TITLE
Set the artifacts workflow to only run when `master` is pushed to.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,5 +1,7 @@
 name: Artifacts
-on: [push]
+on:
+  push:
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
In the current setup, every time I push any branch to my fork I get an artifacts action run, which seems very wasteful. This change makes the actions workflow only run when master is modified. Note that the workflow will still run in forks, but only when the fork's master branch is updated.