### PR TITLE
Make size-diff pass if building master fails.

### DIFF
--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -32,6 +32,11 @@ jobs:
       # The main diff script. Stores the sizes of the example binaries for both
       # the merge commit and the target branch. We display the diff in a
       # separate step to make it easy to navigate to in the GitHub Actions UI.
+      #
+      # If the build on master doesn't work (`make -j2 examples` fails), we
+      # output a warning message and ignore the error. Ignoring the error
+      # prevents this workflow from blocking PRs that fix a broken build in
+      # master.
       - name: Compute sizes
         run: |
           UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-origin}"
@@ -42,12 +47,14 @@ jobs:
           git remote set-branches "${UPSTREAM_REMOTE_NAME}" "${GITHUB_BASE_REF}"
           git fetch --depth=1 "${UPSTREAM_REMOTE_NAME}" "${GITHUB_BASE_REF}"
           git checkout "${UPSTREAM_REMOTE_NAME}/${GITHUB_BASE_REF}"
-          make -j2 examples
-          cargo run --release -p print_sizes >'${{runner.temp}}/base-sizes'
+          make -j2 examples && \
+            cargo run --release -p print_sizes >'${{runner.temp}}/base-sizes' || \
+            echo 'Broken build on the master branch.'
 
       # Computes and displays the size diff. diff returns a nonzero status code
       # if the files differ, and GitHub interprets a nonzero status code as an
       # error. To avoid GitHub interpreting a difference as an error, we add
-      # || exit 0 to the command.
+      # || exit 0 to the command. This also prevents the workflow from failing
+      # if the master build is broken and we didn't generate base-sizes.
       - name: Size diff
         run: diff '${{runner.temp}}/base-sizes' '${{runner.temp}}/merge-sizes' || exit 0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,12 @@ alloc_init = []
 custom_panic_handler = []
 custom_alloc_error_handler = []
 
+[dependencies.linked_list_allocator]
+default-features = false
+features = ["const_mut_refs"]
+optional = true
+version = "0.8.7"
+
 [dependencies]
-linked_list_allocator = { optional = true, version = "0.8.6", default-features = false }
 libtock_codegen = { path = "../codegen" }
 libtock_platform = { path = "platform" }

--- a/core/platform/src/error_code.rs
+++ b/core/platform/src/error_code.rs
@@ -4,33 +4,31 @@
 // ErrorCode is not an enum so that conversion from the kernel's return value (a
 // `usize` in a register) is free.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct ErrorCode {
-    value: usize,
-}
+pub struct ErrorCode(usize);
 
 impl From<usize> for ErrorCode {
     fn from(value: usize) -> ErrorCode {
-        ErrorCode { value }
+        ErrorCode(value)
     }
 }
 
 impl From<ErrorCode> for usize {
     fn from(error_code: ErrorCode) -> usize {
-        error_code.value
+        error_code.0
     }
 }
 
-pub const FAIL: ErrorCode = ErrorCode { value: 1 };
-pub const BUSY: ErrorCode = ErrorCode { value: 2 };
-pub const ALREADY: ErrorCode = ErrorCode { value: 3 };
-pub const OFF: ErrorCode = ErrorCode { value: 4 };
-pub const RESERVE: ErrorCode = ErrorCode { value: 5 };
-pub const INVALID: ErrorCode = ErrorCode { value: 6 };
-pub const SIZE: ErrorCode = ErrorCode { value: 7 };
-pub const CANCEL: ErrorCode = ErrorCode { value: 8 };
-pub const NOMEM: ErrorCode = ErrorCode { value: 9 };
-pub const NOSUPPORT: ErrorCode = ErrorCode { value: 10 };
-pub const NODEVICE: ErrorCode = ErrorCode { value: 11 };
-pub const UNINSTALLED: ErrorCode = ErrorCode { value: 12 };
-pub const NOACK: ErrorCode = ErrorCode { value: 13 };
-pub const BADRVAL: ErrorCode = ErrorCode { value: 1024 };
+pub const FAIL: ErrorCode = ErrorCode(1);
+pub const BUSY: ErrorCode = ErrorCode(2);
+pub const ALREADY: ErrorCode = ErrorCode(3);
+pub const OFF: ErrorCode = ErrorCode(4);
+pub const RESERVE: ErrorCode = ErrorCode(5);
+pub const INVALID: ErrorCode = ErrorCode(6);
+pub const SIZE: ErrorCode = ErrorCode(7);
+pub const CANCEL: ErrorCode = ErrorCode(8);
+pub const NOMEM: ErrorCode = ErrorCode(9);
+pub const NOSUPPORT: ErrorCode = ErrorCode(10);
+pub const NODEVICE: ErrorCode = ErrorCode(11);
+pub const UNINSTALLED: ErrorCode = ErrorCode(12);
+pub const NOACK: ErrorCode = ErrorCode(13);
+pub const BADRVAL: ErrorCode = ErrorCode(1024);

--- a/core/platform/src/error_code.rs
+++ b/core/platform/src/error_code.rs
@@ -1,25 +1,36 @@
-/// An error code returned by the kernel. Tock's system calls return errors as a
-/// negative `isize`. This wraps the isize, and is useful for adding type safety
-/// to APIs.
-
+/// A system call error code. This can either be an error code returned by the
+/// kernel or BADRVAL, which indicates the kernel returned the wrong type of
+/// response to a system call.
+// ErrorCode is not an enum so that conversion from the kernel's return value (a
+// `usize` in a register) is free.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ErrorCode {
-    // Note: value *should* always be negative, but we do not *verify* that so
-    // unsafe code cannot rely on value being negative.
-    value: isize,
+    value: usize,
 }
 
-impl ErrorCode {
-    // Converts the given isize into an ErrorCode. Note that the isize should be
-    // negative, although that is not verified to reduce code size. We don't
-    // implement From because not every isize converts sensibly to an ErrorCode.
-    pub fn new(value: isize) -> ErrorCode {
+impl From<usize> for ErrorCode {
+    fn from(value: usize) -> ErrorCode {
         ErrorCode { value }
     }
 }
 
-impl Into<isize> for ErrorCode {
-    fn into(self) -> isize {
-        self.value
+impl From<ErrorCode> for usize {
+    fn from(error_code: ErrorCode) -> usize {
+        error_code.value
     }
 }
+
+pub const FAIL: ErrorCode = ErrorCode { value: 1 };
+pub const BUSY: ErrorCode = ErrorCode { value: 2 };
+pub const ALREADY: ErrorCode = ErrorCode { value: 3 };
+pub const OFF: ErrorCode = ErrorCode { value: 4 };
+pub const RESERVE: ErrorCode = ErrorCode { value: 5 };
+pub const INVALID: ErrorCode = ErrorCode { value: 6 };
+pub const SIZE: ErrorCode = ErrorCode { value: 7 };
+pub const CANCEL: ErrorCode = ErrorCode { value: 8 };
+pub const NOMEM: ErrorCode = ErrorCode { value: 9 };
+pub const NOSUPPORT: ErrorCode = ErrorCode { value: 10 };
+pub const NODEVICE: ErrorCode = ErrorCode { value: 11 };
+pub const UNINSTALLED: ErrorCode = ErrorCode { value: 12 };
+pub const NOACK: ErrorCode = ErrorCode { value: 13 };
+pub const BADRVAL: ErrorCode = ErrorCode { value: 1024 };

--- a/core/platform/src/lib.rs
+++ b/core/platform/src/lib.rs
@@ -1,12 +1,14 @@
 #![no_std]
 
 mod async_traits;
-mod error_code;
+pub mod error_code;
 mod raw_syscalls;
+pub mod return_type;
 mod syscalls;
 mod syscalls_impl;
 
 pub use async_traits::{CallbackContext, FreeCallback, Locator, MethodCallback};
 pub use error_code::ErrorCode;
 pub use raw_syscalls::{OneArgMemop, RawSyscalls, YieldType, ZeroArgMemop};
+pub use return_type::ReturnType;
 pub use syscalls::Syscalls;

--- a/core/platform/src/return_type.rs
+++ b/core/platform/src/return_type.rs
@@ -1,29 +1,27 @@
 /// `ReturnType` describes what value type the kernel has returned.
 // ReturnType is not an enum so that it can be converted from a u32 for free.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct ReturnType {
-    value: u32,
-}
+pub struct ReturnType(u32);
 
 impl From<u32> for ReturnType {
     fn from(value: u32) -> ReturnType {
-        ReturnType { value }
+        ReturnType(value)
     }
 }
 
 impl From<ReturnType> for u32 {
     fn from(return_type: ReturnType) -> u32 {
-        return_type.value
+        return_type.0
     }
 }
 
-pub const FAILURE: ReturnType = ReturnType { value: 0 };
-pub const FAILURE_U32: ReturnType = ReturnType { value: 1 };
-pub const FAILURE_2_U32: ReturnType = ReturnType { value: 2 };
-pub const FAILURE_U64: ReturnType = ReturnType { value: 3 };
-pub const SUCCESS: ReturnType = ReturnType { value: 128 };
-pub const SUCCESS_U32: ReturnType = ReturnType { value: 129 };
-pub const SUCCESS_2_U32: ReturnType = ReturnType { value: 130 };
-pub const SUCCESS_U64: ReturnType = ReturnType { value: 131 };
-pub const SUCCESS_3_U32: ReturnType = ReturnType { value: 132 };
-pub const SUCCESS_U32_U64: ReturnType = ReturnType { value: 133 };
+pub const FAILURE: ReturnType = ReturnType(0);
+pub const FAILURE_U32: ReturnType = ReturnType(1);
+pub const FAILURE_2_U32: ReturnType = ReturnType(2);
+pub const FAILURE_U64: ReturnType = ReturnType(3);
+pub const SUCCESS: ReturnType = ReturnType(128);
+pub const SUCCESS_U32: ReturnType = ReturnType(129);
+pub const SUCCESS_2_U32: ReturnType = ReturnType(130);
+pub const SUCCESS_U64: ReturnType = ReturnType(131);
+pub const SUCCESS_3_U32: ReturnType = ReturnType(132);
+pub const SUCCESS_U32_U64: ReturnType = ReturnType(133);

--- a/core/platform/src/return_type.rs
+++ b/core/platform/src/return_type.rs
@@ -1,0 +1,29 @@
+/// `ReturnType` describes what value type the kernel has returned.
+// ReturnType is not an enum so that it can be converted from a u32 for free.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ReturnType {
+    value: u32,
+}
+
+impl From<u32> for ReturnType {
+    fn from(value: u32) -> ReturnType {
+        ReturnType { value }
+    }
+}
+
+impl From<ReturnType> for u32 {
+    fn from(return_type: ReturnType) -> u32 {
+        return_type.value
+    }
+}
+
+pub const FAILURE: ReturnType = ReturnType { value: 0 };
+pub const FAILURE_U32: ReturnType = ReturnType { value: 1 };
+pub const FAILURE_2_U32: ReturnType = ReturnType { value: 2 };
+pub const FAILURE_U64: ReturnType = ReturnType { value: 3 };
+pub const SUCCESS: ReturnType = ReturnType { value: 128 };
+pub const SUCCESS_U32: ReturnType = ReturnType { value: 129 };
+pub const SUCCESS_2_U32: ReturnType = ReturnType { value: 130 };
+pub const SUCCESS_U64: ReturnType = ReturnType { value: 131 };
+pub const SUCCESS_3_U32: ReturnType = ReturnType { value: 132 };
+pub const SUCCESS_U32_U64: ReturnType = ReturnType { value: 133 };

--- a/core/platform/src/syscalls_impl.rs
+++ b/core/platform/src/syscalls_impl.rs
@@ -1,6 +1,6 @@
 //! Implements `Syscalls` for all types that implement `RawSyscalls`.
 
-use crate::{RawSyscalls, Syscalls, YieldType};
+use crate::{return_type, RawSyscalls, Syscalls, YieldType};
 
 impl<S: RawSyscalls> Syscalls for S {
     // -------------------------------------------------------------------------
@@ -12,7 +12,6 @@ impl<S: RawSyscalls> Syscalls for S {
     }
 
     fn yield_no_wait() -> bool {
-        // TODO: Introduce a return type abstraction so this 0 isn't hardcoded.
-        Self::raw_yield(YieldType::NoWait) != 0
+        Self::raw_yield(YieldType::NoWait) != return_type::FAILURE.into()
     }
 }


### PR DESCRIPTION
size-diff has been painful in 2 cases:

1. If master is broken, it fails on PRs that fix master's build.
2. If the commands required to build the examples change, it breaks. This happened when we changed rust-toolchain to the TOML format, and removed the `rustup target add` commands from the size-diff workflow. This change was fine once it hit master but broke in the PR.

size-diff still fails if the PR's build fails, so we can still detect PRs that break size-diff's functionality.