### PR TITLE
Switch Mac OS' CI to ARM, and build libtock2 instead of libtock_runtime.

### DIFF
--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -2,8 +2,8 @@
 
 name: ci-mac-os
 
-# We run this workflow during pull request review, but not for Bors merges, as
-# it takes over an hour to run.
+# We run this workflow during pull request review, but not for Bors merges. We
+# can change this if the workflow is reasonably quick and reliable.
 on: pull_request
 
 jobs:
@@ -14,14 +14,21 @@ jobs:
       # Clones a single commit from the libtock-rs repository. The commit cloned
       # is a merge commit between the PR's target branch and the PR's source.
       - name: Clone repository
-        uses: actions/checkout@v2.3.0
+        uses: actions/checkout@v2
 
-      # Install the toolchains we need, then run `cargo build`.
+      # The brew commands are spread out over multiple steps so we can see the
+      # timings for each step in GitHub Actions' dashboard.
+      - name: Brew tap ARMmbed
+        run: brew tap ARMmbed/homebrew-formulae
+
+      - name: Brew update
+        run: brew update
+
+      - name: Brew install
+        run: brew install arm-none-eabi-gcc
+
       - name: Build and Test
         run: |
-          brew tap riscv/riscv
-          brew update
-          brew install riscv-gnu-toolchain --with-multilib
           cd "${GITHUB_WORKSPACE}"
-          LIBTOCK_PLATFORM=hifive1 cargo build -p libtock_runtime \
-            --target=riscv32imac-unknown-none-elf
+          LIBTOCK_PLATFORM=nrf52 cargo build -p libtock_runtime \
+            --target=thumbv7em-none-eabi


### PR DESCRIPTION
Hopefully installing the ARM toolchain will be faster and more reliable than installing the RISC-V toolchain. I also switched the build to `libtock2` so it tests more of the crates.