### PR TITLE
Remove the Tock 1 crates from `libtock-rs`'s build system.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -12,37 +12,34 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install binutils-riscv64-unknown-elf
-          cargo install elf2tab --version 0.4.0
+          sudo apt-get install binutils-arm-none-eabi \
+            binutils-riscv64-unknown-elf
+          cargo install elf2tab
 
-      - name: Build Hello World
+      - name: Build LEDs
         run: |
-          FEATURES="alloc" make flash-apollo3  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-hail  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-nucleo_f429zi  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-nucleo_f446re  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-nrf52840  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-opentitan  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-hifive1  EXAMPLE=hello_world -j2
-          FEATURES="alloc" make flash-nrf52  EXAMPLE=hello_world -j2
+          make -j2 EXAMPLE=leds apollo3
+          make -j2 EXAMPLE=leds hail
+          make -j2 EXAMPLE=leds nucleo_f429zi
+          make -j2 EXAMPLE=leds nucleo_f446re
+          make -j2 EXAMPLE=leds nrf52840
+          make -j2 EXAMPLE=leds opentitan
+          make -j2 EXAMPLE=leds hifive1
+          make -j2 EXAMPLE=leds nrf52
 
-      - name: Build libtock-test
+      - name: Build Low Level Debug
         run: |
-          FEATURES="alloc" make flash-apollo3  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-hail  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-nucleo_f429zi  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-nucleo_f446re  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-nrf52840  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-opentitan  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-hifive1  EXAMPLE=libtock_test -j2
-          FEATURES="alloc" make flash-nrf52  EXAMPLE=libtock_test -j2
-
-      - name: Build extra tests
-        run: |
-          FEATURES="alloc" make flash-opentitan  EXAMPLE=hmac -j2
+          make -j2 EXAMPLE=low_level_debug apollo3
+          make -j2 EXAMPLE=low_level_debug hail
+          make -j2 EXAMPLE=low_level_debug nucleo_f429zi
+          make -j2 EXAMPLE=low_level_debug nucleo_f446re
+          make -j2 EXAMPLE=low_level_debug nrf52840
+          make -j2 EXAMPLE=low_level_debug opentitan
+          make -j2 EXAMPLE=low_level_debug hifive1
+          make -j2 EXAMPLE=low_level_debug nrf52
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v2
         with:
           name: libtock-rs examples
-          path: target/*/tab/*/*/*.tbf
+          path: target/tbf

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -39,7 +39,8 @@ jobs:
       # master.
       - name: Compute sizes
         run: |
-          sudo apt-get install binutils-riscv64-unknown-elf
+          sudo apt-get install binutils-arm-none-eabi \
+            binutils-riscv64-unknown-elf
           UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-origin}"
           GITHUB_BASE_REF="${GITHUB_BASE_REF:-master}"
           cd "${GITHUB_WORKSPACE}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,76 +1,3 @@
-[package]
-name = "libtock"
-version = "0.2.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-license = "MIT/Apache-2.0"
-edition = "2018"
-
-[features]
-alloc = ["libtock_core/alloc"]
-custom_panic_handler = ["libtock_core/custom_panic_handler"]
-custom_alloc_error_handler = ["libtock_core/custom_alloc_error_handler"]
-# In the QEMU-emulated HiFive1 target, we do not have connected GPIO pins or a
-# working timer interface. These features allow the test's user to disable these
-# tests in environments where they will not pass.
-__internal_disable_gpio_in_integration_test = []
-__internal_disable_timer_in_integration_test = []
-
-[dependencies]
-libtock_core = { path = "core" }
-libtock_codegen = { path = "codegen" }
-futures = { version = "0.3.1", default-features = false, features = ["unstable", "cfg-target-has-atomic"] }
-
-[dev-dependencies]
-corepack = { version = "0.4.0", default-features = false, features = ["alloc"] }
-# We pin the serde version because newer serde versions may not be compatible
-# with the nightly toolchain used by libtock-rs.
-serde = { version = "=1.0.114", default-features = false, features = ["derive"] }
-ctap2-authenticator = { git = "https://gitlab.com/ctap2-authenticator/ctap2-authenticator.git" }
-p256 = { version = "0.7" , default-features = false, features = ["arithmetic", "ecdsa", "ecdsa-core"] }
-# p256 depends transitively on bitvec 0.18. bitvec 0.18.5 depends on radium
-# 0.3.0, which does not work on platforms that lack atomics. This prevents cargo
-# from selecting bitvec 0.18.5, which avoids the radium 0.3.0 issue.
-bitvec = { version = "<=0.18.4", default-features = false }
-subtle = { version = "2.3.0", default-features = false, features = ["i128"] }
-generic-array = { version = "0.14.3" }
-libmctp = { version = "0.1.0" }
-
-# We need to override this to allow builds for targets that don't support atomics.
-# Once a version newer then 0.4.11 is released we can update to use that.
-# See: https://github.com/rust-lang/log/releases
-[patch.crates-io]
-log = { git = "https://github.com/rust-lang/log.git", branch = "master" }
-
-[[example]]
-name = "alloc_error"
-path = "examples-features/alloc_error.rs"
-required-features = ["alloc", "custom_alloc_error_handler"]
-
-[[example]]
-name = "ctap_features"
-path = "examples-features/ctap.rs"
-required-features = ["alloc", "custom_alloc_error_handler"]
-
-[[example]]
-name = "ble_scanning"
-path = "examples-features/ble_scanning.rs"
-required-features = ["alloc"]
-
-[[example]]
-name = "libtock_test"
-path = "examples-features/libtock_test.rs"
-required-features = ["alloc"]
-
-[[example]]
-name = "panic"
-path = "examples-features/panic.rs"
-required-features = ["custom_panic_handler"]
-
-[[example]]
-name = "simple_ble"
-path = "examples-features/simple_ble.rs"
-required-features = ["alloc"]
-
 [profile.dev]
 panic = "abort"
 lto = true
@@ -86,15 +13,12 @@ exclude = ["tock", "tock2"]
 members = [
     "apis/leds",
     "apis/low_level_debug",
-    "codegen",
-    "core",
     "libtock2",
     "panic_handlers/small_panic",
     "platform",
     "runner",
     "runtime",
     "syscalls_tests",
-    "test_runner",
     "tools/print_sizes",
     "ufmt",
     "unittest",

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,8 @@ usage:
 	@echo " - stm32f3discovery"
 	@echo
 	@echo "Run 'make setup' to setup Rust to build libtock-rs."
-	@echo "Run 'make <board>' to build libtock-rs for that board"
-	@echo "    Set the DEBUG flag to enable the debug build"
-	@echo "    Set the FEATURES flag to enable features"
-	@echo "Run 'make flash-<board> EXAMPLE=<>' to flash EXAMPLE to that board"
+	@echo "Run 'make <board> EXAMPLE=<>' to build EXAMPLE for that board."
+	@echo "Run 'make flash-<board> EXAMPLE=<>' to flash EXAMPLE to a tockloader-supported board."
 	@echo "Run 'make qemu-example EXAMPLE=<>' to run EXAMPLE in QEMU"
 	@echo "Run 'make test' to test any local changes you have made"
 	@echo "Run 'make print-sizes' to print size data for the example binaries"
@@ -39,28 +37,16 @@ release=--release
 endif
 
 .PHONY: setup
-setup: setup-qemu setup-qemu-2
+setup: setup-qemu-2
 	cargo install elf2tab
 	cargo install stack-sizes
 	cargo miri setup
-
-# Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
-# patches to better support boards that Tock supports.
-.PHONY: setup-qemu
-setup-qemu:
-	CI=true $(MAKE) -C tock ci-setup-qemu
 
 # Sets up QEMU in the tock2/ directory. We use Tock's QEMU which may contain
 # patches to better support boards that Tock supports.
 .PHONY: setup-qemu-2
 setup-qemu-2:
 	CI=true $(MAKE) -C tock2 ci-setup-qemu
-
-# Builds a Tock kernel for the HiFive board for use by QEMU tests.
-.PHONY: kernel-hifive
-kernel-hifive:
-	$(MAKE) -C tock/boards/hifive1 \
-		$(CURDIR)/tock/target/riscv32imac-unknown-none-elf/release/hifive1.elf
 
 # Builds a Tock 2.0 kernel for the HiFive board for use by QEMU tests.
 # TODO: After Tock 2.0 is released, we should merge the tock/ and tock2/
@@ -89,22 +75,14 @@ qemu-example: kernel-hifive-2
 	LIBTOCK_PLATFORM="hifive1" cargo run --example "$(EXAMPLE)" -p libtock2 \
 		--release --target=riscv32imac-unknown-none-elf -- --deploy qemu
 
-# Runs the libtock_test tests in QEMU on a simulated HiFive board.
-.PHONY: test-qemu-hifive
-test-qemu-hifive: kernel-hifive
-	PLATFORM=hifive1 cargo rrv32imac --example libtock_test --features=alloc \
-		--features=__internal_disable_gpio_in_integration_test \
-		--features=__internal_disable_timer_in_integration_test
-	cargo run -p test_runner
-
+# Build the examples on both a RISC-V target and an ARM target. We pick
+# opentitan as the RISC-V target because it lacks atomics.
 .PHONY: examples
 examples:
-	PLATFORM=nrf52 cargo build --release --target=thumbv7em-none-eabi --examples -p libtock -p libtock_core
-	PLATFORM=nrf52 cargo build --release --target=thumbv7em-none-eabi --examples --features=alloc
-	PLATFORM=nrf52 cargo build --release --target=thumbv7em-none-eabi --example panic --features=custom_panic_handler,custom_alloc_error_handler
-	PLATFORM=nrf52 cargo build --release --target=thumbv7em-none-eabi --example alloc_error --features=alloc,custom_alloc_error_handler
-	# Important: This tests a platform without atomic instructions.
-	PLATFORM=opentitan cargo build --release --target=riscv32imc-unknown-none-elf --examples -p libtock -p libtock_core
+	LIBTOCK_PLATFORM=nrf52 cargo build --examples --release \
+		--target=thumbv7em-none-eabi
+	LIBTOCK_PLATFORM=opentitan cargo build --examples --release \
+		--target=riscv32imc-unknown-none-elf
 
 # Arguments to pass to cargo to exclude crates that require a Tock runtime.
 # This is largely libtock_runtime and crates that depend on libtock_runtime.
@@ -115,13 +93,12 @@ EXCLUDE_RUNTIME := --exclude libtock2 --exclude libtock_runtime --exclude libtoc
 # Arguments to pass to cargo to exclude crates that cannot be tested by Miri. In
 # addition to excluding libtock_runtime, Miri also cannot test proc macro crates
 # (and in fact will generate broken data that causes cargo test to fail).
-EXCLUDE_MIRI := $(EXCLUDE_RUNTIME) --exclude libtock_codegen \
-                --exclude ufmt-macros
+EXCLUDE_MIRI := $(EXCLUDE_RUNTIME) --exclude ufmt-macros
 
 # Arguments to pass to cargo to exclude `std` and crates that depend on it. Used
 # when we build a crate for an embedded target, as those targets lack `std`.
 EXCLUDE_STD := --exclude libtock_unittest --exclude print_sizes \
-               --exclude runner --exclude syscalls_tests --exclude test_runner
+               --exclude runner --exclude syscalls_tests
 
 # Some of our crates should build with a stable toolchain. This verifies those
 # crates don't depend on unstable features by using cargo check. We specify a
@@ -130,29 +107,20 @@ EXCLUDE_STD := --exclude libtock_unittest --exclude print_sizes \
 .PHONY: test-stable
 test-stable:
 	CARGO_TARGET_DIR="target/stable-toolchain" cargo +stable check --workspace \
-		$(EXCLUDE_RUNTIME) --exclude libtock --exclude libtock_core
+		$(EXCLUDE_RUNTIME)
 
 .PHONY: test
 test: examples test-stable
-	PLATFORM=nrf52 cargo test $(EXCLUDE_RUNTIME) --workspace
-	# TODO: When we have a working embedded test harness, change the libtock2
-	# builds to --all-targets rather than --examples.
-	# Build libtock2 on both a RISC-V target and an ARM target. We pick
-	# opentitan as the RISC-V target because it lacks atomics.
-	LIBTOCK_PLATFORM=opentitan cargo build --examples --release \
-		--target=riscv32imc-unknown-none-elf -p libtock2
-	LIBTOCK_PLATFORM=nrf52 cargo build --examples --release \
-		--target=thumbv7em-none-eabi -p libtock2
-	LIBTOCK_PLATFORM=nrf52 PLATFORM=nrf52 cargo fmt --all -- --check
-	PLATFORM=nrf52 cargo clippy --all-targets $(EXCLUDE_RUNTIME) --workspace
-	# TODO: Add a clippy invocation for an ARM platform, once the Tock 1.0
-	# crates are removed. It is omitted because the Tock 1.0 crates don't
-	# currently pass clippy on ARM.
-	LIBTOCK_PLATFORM=hifive1 PLATFORM=hifive1 cargo clippy $(EXCLUDE_STD) \
+	cargo test $(EXCLUDE_RUNTIME) --workspace
+	LIBTOCK_PLATFORM=nrf52 cargo fmt --all -- --check
+	cargo clippy --all-targets $(EXCLUDE_RUNTIME) --workspace
+	LIBTOCK_PLATFORM=nrf52 cargo clippy $(EXCLUDE_STD) \
+		--target=thumbv7em-none-eabi --workspace
+	LIBTOCK_PLATFORM=hifive1 cargo clippy $(EXCLUDE_STD) \
 		--target=riscv32imac-unknown-none-elf --workspace
-	PLATFORM=nrf52 cargo miri test $(EXCLUDE_MIRI) --workspace
+	cargo miri test $(EXCLUDE_MIRI) --workspace
 	MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-track-raw-pointers" \
-		PLATFORM=nrf52 cargo miri test $(EXCLUDE_MIRI) --workspace
+		cargo miri test $(EXCLUDE_MIRI) --workspace
 	echo '[ SUCCESS ] libtock-rs tests pass'
 
 .PHONY: analyse-stack-sizes
@@ -161,102 +129,133 @@ analyse-stack-sizes:
 
 .PHONY: apollo3
 apollo3:
-	PLATFORM=apollo3 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
-
-.PHONY: flash-apollo3
-flash-apollo3:
-	PLATFORM=apollo3 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=apollo3 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/apollo3
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/apollo3
 
 .PHONY: hail
 hail:
-	PLATFORM=hail cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
+	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/hail
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/hail
 
 .PHONY: flash-hail
 flash-hail:
-	PLATFORM=hail cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: microbit_v2
 microbit_v2:
-	PLATFORM=microbit_v2 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
+	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/microbit_v2
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/microbit_v2
 
 .PHONY: flash-microbit_v2
 flash-microbit_v2:
-	PLATFORM=microbit_v2 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: nucleo_f429zi
 nucleo_f429zi:
-	PLATFORM=nucleo_f429zi cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
-
-.PHONY: flash-nucleo_f429zi
-flash-nucleo_f429zi:
-	PLATFORM=nucleo_f429zi cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=nucleo_f429zi cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/nucleo_f429zi
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/nucleo_f429zi
 
 .PHONY: nucleo_f446re
 nucleo_f446re:
-	PLATFORM=nucleo_f446re cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
-
-.PHONY: flash-nucleo_f446re
-flash-nucleo_f446re:
-	PLATFORM=nucleo_f446re cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=nucleo_f446re cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/nucleo_f446re
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/nucleo_f446re
 
 .PHONY: nrf52840
 nrf52840:
-	PLATFORM=nrf52840 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
+	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/nrf52840
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/nrf52840
 
 .PHONY: flash-nrf52840
 flash-nrf52840:
-	PLATFORM=nrf52840 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: stm32f3discovery
 stm32f3discovery:
-	PLATFORM=stm32f3discovery cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
-	
-.PHONY: flash-stm32f3discovery
-flash-stm32f3discovery:
-	PLATFORM=stm32f3discovery cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=stm32f3discovery cargo run --example $(EXAMPLE) \
+		$(features) --target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/stm32f3discovery
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/stm32f3discovery
 
 .PHONY: opentitan
 opentitan:
-	PLATFORM=opentitan cargo build $(release) --target=riscv32imc-unknown-none-elf --examples $(features)
-
-.PHONY: flash-opentitan
-flash-opentitan:
-	PLATFORM=opentitan cargo run $(release) --target=riscv32imc-unknown-none-elf --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=opentitan cargo run --example $(EXAMPLE) $(features) \
+		--target=riscv32imc-unknown-none-elf $(release)
+	mkdir -p target/tbf/opentitan
+	cp target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tab \
+		target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
+		target/tbf/opentitan
 
 .PHONY: hifive1
 hifive1:
-	PLATFORM=hifive1 cargo build $(release) --target=riscv32imac-unknown-none-elf --examples $(features)
-
-.PHONY: flash-hifive1
-flash-hifive1:
-	PLATFORM=hifive1 cargo run $(release) --target=riscv32imac-unknown-none-elf --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=hifive1 cargo run --example $(EXAMPLE) $(features) \
+		--target=riscv32imac-unknown-none-elf $(release)
+	mkdir -p target/tbf/hifive1
+	cp target/riscv32imac-unknown-none-elf/release/examples/$(EXAMPLE).tab \
+		target/riscv32imac-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
+		target/tbf/hifive1
 
 .PHONY: nrf52
 nrf52:
-	PLATFORM=nrf52 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
+	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/nrf52
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/nrf52
 
 .PHONY: flash-nrf52
 flash-nrf52:
-	PLATFORM=nrf52 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: imxrt1050
 imxrt1050:
-	PLATFORM=imxrt1050 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
-
-.PHONY: flash-imxrt1050
-flash-imxrt1050:
-	PLATFORM=imxrt1050 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=imxrt1050 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/imxrt1050
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/imxrt1050
 
 .PHONY: msp432
 msp432:
-	PLATFORM=msp432 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
-
-.PHONY: flash-msp432
-flash-msp432:
-	PLATFORM=msp432 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+	LIBTOCK_PLATFORM=msp432 cargo run --example $(EXAMPLE) $(features) \
+		--target=thumbv7em-none-eabi $(release)
+	mkdir -p target/tbf/msp432
+	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/tbf/msp432
 
 .PHONY: clean
 clean:
 	cargo clean
-	$(MAKE) -C tock clean
 	$(MAKE) -C tock2 clean


### PR DESCRIPTION
Now, all the cargo and Makefile actions operate on only the Tock 2 crates. I have not yet performed renamings (e.g. tock2 -> tock), or deleted much code.

The purpose of the per-board actions were unclear to me, and they seemed somewhat inconsistent. As far as I can tell, they're primarily used by the artifacts workflow. Previously, the action named `<board>` compiled the examples into ELF files, and the action named `flash-<board>` converted a specific example into a TBF file and deployed it *if supported by tockloader*. Now, the action named `<board>` compiles a specific example into a TBF file, and `flash-<board>` deploys a specific example. I removed the `flash-<board>` targets for platforms that we're unable to automatically deploy to.