### PR TITLE
Define a MSRV, use that toolchain by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Cargo.lock
+/nightly/target
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,13 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 name = "libtock"
 repository = "https://www.github.com/tock/libtock-rs"
+rust-version.workspace = true
 version = "0.1.0"
+
+[workspace.package]
+# This must be kept in sync with rust-toolchain.toml; please see that file for
+# more information.
+rust-version = "1.70"
 
 [dependencies]
 libtock_adc = { path = "apis/adc"}

--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# This is the nightly Rust toolchain used by `make test`.
+[toolchain]
+channel = "nightly-2023-08-22"
+components = ["miri"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,9 +1,0 @@
-[toolchain]
-# See https://rust-lang.github.io/rustup-components-history/ for a list of
-# recently nightlies and what components are available for them.
-channel = "nightly-2023-08-22"
-components = ["clippy", "miri", "rustfmt"]
-targets = ["thumbv6m-none-eabi",
-           "thumbv7em-none-eabi",
-           "riscv32imac-unknown-none-elf",
-           "riscv32imc-unknown-none-elf"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+[toolchain]
+# This is libtock-rs' Minimum Supported Rust Version (MSRV).
+#
+# Update policy: Update this if doing so allows you to use a Rust feature that
+# you'd like to use. When you do so, update this to the first Rust version that
+# includes that feature. Whenever this value is updated, the rust-version field
+# in Cargo.toml must be updated as well.
+channel = "1.70"
+components = ["clippy", "rustfmt"]
+targets = ["thumbv6m-none-eabi",
+           "thumbv7em-none-eabi",
+           "riscv32imac-unknown-none-elf",
+           "riscv32imc-unknown-none-elf"]


### PR DESCRIPTION
This PR defines a Minimum Supported Rust Version. It specifies that toolchain in `rust-toolchain`, so `rustup` will use that toolchain by default. The `test-stable` make action is removed, as it is now redundant.

We still need the nightly toolchain for Miri. Instead of specifying the nightly toolchain version via the command line, I created a new `nightly/rust-toolchain.toml` file that specifies the toolchain. The benefit is this makes `rustup` automatically install the nightly toolchain *including Miri*. This should stop the toil we currently have where every time the Rust toolchain is updated, everyone using `make test` has to manually install new toolchains and Miri. The downside is it's kinda ugly.

I set the MSRV to 1.70 so this doesn't conflict with #498.

I will send another PR that adds `rust-version.workspace = true` to all the `Cargo.toml` files in this repository; I didn't want to clutter this PR with those changes.